### PR TITLE
Fix equals sign not being accepted in `value` tag.

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,6 +1,7 @@
 name: example
 
 environment:
+  sdk: '>=2.15.1 <3.0.0'
 
 dependencies:
   bbob_dart:

--- a/lib/src/bbob_parser/lexer.dart
+++ b/lib/src/bbob_parser/lexer.dart
@@ -127,12 +127,15 @@ class Lexer {
   }
 
   /// Parses params inside [myTag---params goes here---]content[/myTag]
-  Attribute _parseAttrs(str) {
-    String? tagName;
-    bool skipSpecialChars = false;
+  Attribute _parseAttrs(String str) {
+    String? tagName = null;
+    var skipSpecialChars = false;
 
     final attrTokens = <Token>[];
+    final isSingleValueTag = !str.contains(space);
     final attrCharGrabber = CharGrabber(str);
+
+    var tagMode = TagState.NAME;
 
     bool validAttr(char) {
       final isEqual = char == equal;
@@ -157,32 +160,76 @@ class Lexer {
         }
       }
 
-      return !isEqual && !isWhiteSpace;
+      return !isWhiteSpace;
     }
 
-    void _nextAttr() {
-      final attrStr = attrCharGrabber.grabWhile(validAttr);
-      final currChar = attrCharGrabber.current;
+    // Represents: https://github.com/JiLiZART/BBob/blob/99c629e66678e40cec7b924eda2f1bfe0d46b941/packages/bbob-parser/src/lexer.ts#L104
+    TagState _nextTagState() {
+      if (tagMode == TagState.ATTRIBUTE) {
+         // Grab untill end, whitespace or end tag.
+         final validAttrName = (String? char) => !(char == '=' || _isWhiteSpace(char));
+         final name = attrCharGrabber.grabWhile(validAttrName);
 
-      // first string before space is a tag name [tagName params...]
-      if (tagName == null) {
-        tagName = attrStr;
-      } else if (_isWhiteSpace(currChar) ||
-          currChar == doubleQuote ||
-          !attrCharGrabber.hasNext) {
+         final nextchar = attrCharGrabber.current;
+         final isEnd = attrCharGrabber.isLast;
+         final isValue = nextchar != equal;
+
+         attrCharGrabber.skip();
+
+         // Tag has ended already, this is a attribute value.
+         if (isEnd || isValue) {
+           final escaped = unquote(trimChar(name, doubleQuote));
+           attrTokens.add(Token(
+               TokenType.AttributeValue, escaped, _linePosition, _columnPosition));
+         } else {
+           // Defo a name
+           attrTokens.add(Token(
+               TokenType.AttributeName, name, _linePosition, _columnPosition));
+         }
+
+         if (isEnd) {
+           return TagState.NAME;
+         }
+
+         if (isValue) {
+           return TagState.ATTRIBUTE;
+         }
+
+         return TagState.VALUE;
+      }
+
+      if (tagMode == TagState.VALUE) {
+        final attrStr = attrCharGrabber.grabWhile(validAttr);
+        attrCharGrabber.skip();
+
         final escaped = unquote(trimChar(attrStr, doubleQuote));
         attrTokens.add(Token(
             TokenType.AttributeValue, escaped, _linePosition, _columnPosition));
-      } else {
-        attrTokens.add(Token(
-            TokenType.AttributeName, attrStr, _linePosition, _columnPosition));
+
+        if (attrCharGrabber.isLast) return TagState.NAME;
+        return TagState.ATTRIBUTE;
       }
 
+      // Ideally this code should not be called twice since it will
+      // overwrite the tagName with (probably) some garbage. Could also throw an exception.
+      assert(tagName == null);
+
+      final validName = (String? char) => !(char == equal || _isWhiteSpace(char) || attrCharGrabber.isLast);
+      final name = attrCharGrabber.grabWhile(validName);
       attrCharGrabber.skip();
+
+      tagName = name;
+
+      if (isSingleValueTag) {
+        return TagState.VALUE;
+      }
+
+      final hasEq = str.contains(equal);
+      return hasEq ? TagState.ATTRIBUTE : TagState.VALUE;
     }
 
     while (attrCharGrabber.hasNext) {
-      _nextAttr();
+      tagMode = _nextTagState();
     }
 
     return Attribute(
@@ -287,4 +334,11 @@ class Attribute {
   final List<Token> attrs;
 
   const Attribute({required this.tag, required this.attrs});
+}
+
+/// Represents the current state of parsing a tag.
+enum TagState {
+  NAME,
+  VALUE,
+  ATTRIBUTE,
 }

--- a/lib/src/bbob_parser/lexer.dart
+++ b/lib/src/bbob_parser/lexer.dart
@@ -163,7 +163,9 @@ class Lexer {
       return !isWhiteSpace;
     }
 
-    // Represents: https://github.com/JiLiZART/BBob/blob/99c629e66678e40cec7b924eda2f1bfe0d46b941/packages/bbob-parser/src/lexer.ts#L104
+    /// Processes part of a tag and returns a `TagState` that should be used for the next iteration.
+    ///
+    /// Represents: https://github.com/JiLiZART/BBob/blob/99c629e66678e40cec7b924eda2f1bfe0d46b941/packages/bbob-parser/src/lexer.ts#L104
     TagState _nextTagState() {
       if (tagMode == TagState.ATTRIBUTE) {
          // Grab untill end, whitespace or end tag.

--- a/lib/src/bbob_parser/lexer.dart
+++ b/lib/src/bbob_parser/lexer.dart
@@ -182,7 +182,7 @@ class Lexer {
            attrTokens.add(Token(
                TokenType.AttributeValue, escaped, _linePosition, _columnPosition));
          } else {
-           // Defo a name
+           // Definitely a name
            attrTokens.add(Token(
                TokenType.AttributeName, name, _linePosition, _columnPosition));
          }

--- a/test/bbob_parser/lexer_test.dart
+++ b/test/bbob_parser/lexer_test.dart
@@ -136,6 +136,32 @@ void main() {
         validateTokens(tokens, output);
       });
 
+      test('url tag as param without quotes', () {
+        const input = '[url=http://site/]Text[/url]';
+        final tokens = tokenize(input);
+        const output = [
+          Token(TokenType.Tag, 'url', 0, 18),
+          Token(TokenType.AttributeValue, 'http://site/', 0, 18),
+          Token(TokenType.Word, 'Text', 0, 22),
+          Token(TokenType.Tag, '/url', 0, 28),
+        ];
+
+        validateTokens(tokens, output);
+      });
+
+      test('url tag as param without quotes and equals sign', () {
+        const input = '[url=http://site/?x=y]Text[/url]';
+        final tokens = tokenize(input);
+        const output = [
+          Token(TokenType.Tag, 'url', 0, 22),
+          Token(TokenType.AttributeValue, 'http://site/?x=y', 0, 22),
+          Token(TokenType.Word, 'Text', 0, 26),
+          Token(TokenType.Tag, '/url', 0, 32),
+        ];
+
+        validateTokens(tokens, output);
+      });
+
       test('tag with escaped quotemark param', () {
         const input = '[url text="Foo \\"Bar"]Text[/url]';
         final tokens = tokenize(input);


### PR DESCRIPTION
This PR fixes the issue mentioned in #6.
It rewrites some of the parsing and adds additional tests.

**Test that currently doesn't pass in the latest release of `bbob_dart`:**
```dart
      test('url tag as param without quotes and equals sign', () {
        const input = '[url=http://site/?x=y]Text[/url]';
        final tokens = tokenize(input);
        const output = [
          Token(TokenType.Tag, 'url', 0, 22),
          Token(TokenType.AttributeValue, 'http://site/?x=y', 0, 22),
          Token(TokenType.Word, 'Text', 0, 26),
          Token(TokenType.Tag, '/url', 0, 32),
        ];

        validateTokens(tokens, output);
      });
```


**After this PR:**
```bash
00:00 +42: All tests passed!
```